### PR TITLE
Command Line Options

### DIFF
--- a/Amsi-Killer/Source.cpp
+++ b/Amsi-Killer/Source.cpp
@@ -31,9 +31,6 @@ GetPID(
 				Process32Next(hSnap, &pE);
 			do
 			{
-				/*wchar_t wtext[260];
-				mbstowcs_s(wtext, pE.szExeFile, strlen(pE.szExeFile) + 1);
-				LPCWSTR ptr = wtext;*/
 				size_t size = strlen(pE.szExeFile) + 1;
 				wchar_t* targetProcessName = new wchar_t[size];
 				size_t outSize;


### PR DESCRIPTION
# Summary

Added the command line options.

`-i <PID>` Targets specific PID
`-p <Process Name>` Targets specific target by name (first occurrence)

No arguments uses the PID of the process itself.

# Misc

Fixed a bug of comparing the process target name in `GetPID` function.
Added output when process exits to inform the user where the bypass failed.

# Reference

Enhancement requested here: https://github.com/ZeroMemoryEx/Amsi-Killer/issues/2